### PR TITLE
feat: enhance quantum models for multivariate forecasting

### DIFF
--- a/ThermoTwinAI-Quantum/evaluation/evaluate_models.py
+++ b/ThermoTwinAI-Quantum/evaluation/evaluate_models.py
@@ -1,21 +1,27 @@
 # evaluation/evaluate_models.py
-from sklearn.metrics import mean_absolute_error, mean_squared_error
-from scipy.stats import pearsonr
 import numpy as np
-import matplotlib.pyplot as plt
 import os
 
-def evaluate_model(y_true, y_pred, name="Model", plot=False):
-    mae = mean_absolute_error(y_true, y_pred)
-    rmse = np.sqrt(mean_squared_error(y_true, y_pred))
-    corr, _ = pearsonr(y_true, y_pred)
+try:  # Optional dependency for plotting
+    import matplotlib.pyplot as plt
+except Exception:  # pragma: no cover - plotting is optional
+    plt = None
+
+
+def evaluate_model(y_true, y_pred, name: str = "Model", plot: bool = False):
+    """Print common regression metrics and optionally plot predictions."""
+
+    # Metrics computed with numpy to avoid external dependencies
+    mae = np.mean(np.abs(y_true - y_pred))
+    rmse = np.sqrt(np.mean((y_true - y_pred) ** 2))
+    corr = np.corrcoef(y_true, y_pred)[0, 1]
 
     print(f"📌 {name} Evaluation")
     print(f"   MAE     = {mae:.6f}")
     print(f"   RMSE    = {rmse:.6f}")
     print(f"   Corr(R) = {corr:.4f}")
 
-    if plot:
+    if plot and plt is not None:
         os.makedirs("plots", exist_ok=True)
         plt.figure()
         plt.plot(y_true, label="True")

--- a/ThermoTwinAI-Quantum/main.py
+++ b/ThermoTwinAI-Quantum/main.py
@@ -4,56 +4,66 @@ from models.quantum_lstm import train_quantum_lstm
 from models.quantum_prophet import train_quantum_prophet
 from evaluation.evaluate_models import evaluate_model
 import numpy as np
-import pandas as pd
+import csv
 import os
+import argparse
 
-def generate_tftec_cop_data(n_weeks=156):
+def generate_tftec_cop_data(n_weeks: int = 156):
+    """Create a synthetic multivariate dataset with simple degradation effects."""
+
     base_cop = 1.5
     time = np.arange(n_weeks)
 
     # Additional synthetic sensor signals
     ambient_temp = 25 + 5 * np.sin(2 * np.pi * time / 52) + np.random.normal(0, 0.5, n_weeks)
-    current = 5 + 0.5 * np.sin(2 * np.pi * time / 26) - 0.01 * time + np.random.normal(0, 0.1, n_weeks)
-    zt = 1.0 + 0.1 * np.cos(2 * np.pi * time / 52) - 0.005 * time + np.random.normal(0, 0.01, n_weeks)
+    module_current = 5 + 0.5 * np.sin(2 * np.pi * time / 26) - 0.01 * time + np.random.normal(0, 0.1, n_weeks)
+    humidity = 40 + 10 * np.sin(2 * np.pi * time / 52) + np.random.normal(0, 1.0, n_weeks)
 
     # Degradation + noise + anomalies
     degradation = 0.0015 * time
     anomalies = np.zeros(n_weeks)
     for idx in np.random.choice(range(20, n_weeks - 10), size=4, replace=False):
-        anomalies[idx:idx+5] -= np.linspace(0.05, 0.15, 5)
+        anomalies[idx : idx + 5] -= np.linspace(0.05, 0.15, 5)
     noise = np.random.normal(0, 0.01, n_weeks)
 
     # Sensor influence on CoP
     cop = base_cop - degradation + anomalies + noise
-    cop += 0.002 * (ambient_temp - 25) - 0.001 * (current - 5) + 0.05 * (zt - 1)
+    cop += 0.002 * (ambient_temp - 25) - 0.001 * (module_current - 5) + 0.0005 * (humidity - 40)
     cop = np.clip(cop, 0, None)
 
-    df = pd.DataFrame(
-        {
-            "week": time,
-            "CoP": cop,
-            "ambient_temp": ambient_temp,
-            "current": current,
-            "ZT": zt,
-        }
-    )
-
     os.makedirs("data", exist_ok=True)
-    df.to_csv("data/synthetic_tftec_cop.csv", index=False)
+    with open("data/synthetic_tftec_cop.csv", "w", newline="") as f:
+        writer = csv.writer(f)
+        writer.writerow(["week", "CoP", "ambient_temp", "module_current", "humidity"])
+        for i in range(n_weeks):
+            writer.writerow([time[i], cop[i], ambient_temp[i], module_current[i], humidity[i]])
+
     print("✅ Synthetic multivariate data saved to data/synthetic_tftec_cop.csv")
 
 def main():
+    parser = argparse.ArgumentParser(description="ThermoTwinAI-Quantum pipeline")
+    parser.add_argument("--window", type=int, default=15, help="Sliding window size")
+    parser.add_argument("--epochs", type=int, default=50, help="Training epochs")
+    parser.add_argument("--lr", type=float, default=0.005, help="Learning rate")
+    args = parser.parse_args()
+
     print("🚀 ThermoTwinAI-Quantum Forecasting Pipeline")
 
     generate_tftec_cop_data()
 
-    X_train, y_train, X_test, y_test = load_and_split_data("data/synthetic_tftec_cop.csv", window_size=15)
+    X_train, y_train, X_test, y_test = load_and_split_data(
+        "data/synthetic_tftec_cop.csv", window_size=args.window
+    )
 
     print("\n🔮 Training Quantum LSTM...")
-    qlstm_preds = train_quantum_lstm(X_train, y_train, X_test, epochs=50, lr=0.005)
+    qlstm_preds = train_quantum_lstm(
+        X_train, y_train, X_test, epochs=args.epochs, lr=args.lr
+    )
 
     print("\n📈 Training Quantum NeuralProphet...")
-    qprophet_preds = train_quantum_prophet(X_train, y_train, X_test, epochs=50, lr=0.005)
+    qprophet_preds = train_quantum_prophet(
+        X_train, y_train, X_test, epochs=args.epochs, lr=args.lr
+    )
 
     print("\n📊 Evaluation:")
     evaluate_model(y_test, qlstm_preds, name="Quantum LSTM", plot=True)

--- a/ThermoTwinAI-Quantum/models/quantum_lstm.py
+++ b/ThermoTwinAI-Quantum/models/quantum_lstm.py
@@ -2,26 +2,84 @@
 import torch
 import torch.nn as nn
 from utils.quantum_layers import QuantumLayer
-import numpy as np
+
 
 class QLSTMModel(nn.Module):
-    def __init__(self, input_size):
+    """Quantum enhanced LSTM model.
+
+    A deeper/bidirectional LSTM encodes the temporal dynamics. The final
+    hidden state is projected down to four features which are passed through
+    a configurable quantum layer followed by a linear readout. An attention
+    mechanism is included to allow the network to emphasise informative time
+    steps.
+    """
+
+    def __init__(
+        self,
+        input_size: int,
+        hidden_size: int = 16,
+        num_layers: int = 2,
+        bidirectional: bool = True,
+        q_layers: int = 8,
+    ) -> None:
         super().__init__()
-        self.lstm = nn.LSTM(input_size, 8, batch_first=True)
-        self.q_layer = QuantumLayer()
+
+        self.bidirectional = bidirectional
+        lstm_hidden = hidden_size * (2 if bidirectional else 1)
+
+        # Stacked/bidirectional LSTM
+        self.lstm = nn.LSTM(
+            input_size,
+            hidden_size,
+            num_layers=num_layers,
+            batch_first=True,
+            bidirectional=bidirectional,
+        )
+
+        # Simple self-attention over the time dimension
+        self.attn = nn.MultiheadAttention(lstm_hidden, num_heads=1, batch_first=True)
+
+        # Project to the number of qubits expected by the quantum layer
+        self.q_proj = nn.Linear(lstm_hidden, 4)
+        self.q_layer = QuantumLayer(n_layers=q_layers)
         self.fc = nn.Linear(4, 1)
 
-    def forward(self, x):
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
         lstm_out, _ = self.lstm(x)
-        last_out = lstm_out[:, -1, :]
-        q_input = last_out[:, :4]
+
+        # Attention emphasises informative time steps
+        attn_out, _ = self.attn(lstm_out, lstm_out, lstm_out)
+        last_out = attn_out[:, -1, :]
+
+        # Quantum feature map
+        q_input = self.q_proj(last_out)
         q_out = self.q_layer(q_input)
         return self.fc(q_out)
 
-def train_quantum_lstm(X_train, y_train, X_test, epochs=50, lr=0.005):
+
+def train_quantum_lstm(
+    X_train,
+    y_train,
+    X_test,
+    epochs: int = 50,
+    lr: float = 0.005,
+    hidden_size: int = 16,
+    num_layers: int = 2,
+    bidirectional: bool = True,
+    q_layers: int = 8,
+):
+    """Train the ``QLSTMModel`` and return predictions for ``X_test``."""
+
     device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
     num_features = X_train.shape[2]
-    model = QLSTMModel(num_features).to(device)
+    model = QLSTMModel(
+        num_features,
+        hidden_size=hidden_size,
+        num_layers=num_layers,
+        bidirectional=bidirectional,
+        q_layers=q_layers,
+    ).to(device)
+
     criterion = nn.MSELoss()
     optimizer = torch.optim.Adam(model.parameters(), lr=lr)
 
@@ -36,7 +94,7 @@ def train_quantum_lstm(X_train, y_train, X_test, epochs=50, lr=0.005):
         loss = criterion(output, y_train)
         loss.backward()
         optimizer.step()
-        print(f"[QLSTM] Epoch {epoch+1}/{epochs} - Loss: {loss.item():.6f}")
+        print(f"[QLSTM] Epoch {epoch + 1}/{epochs} - Loss: {loss.item():.6f}")
 
     model.eval()
     with torch.no_grad():

--- a/ThermoTwinAI-Quantum/utils/preprocessing.py
+++ b/ThermoTwinAI-Quantum/utils/preprocessing.py
@@ -1,21 +1,28 @@
 # utils/preprocessing.py
-import pandas as pd
 import numpy as np
-from sklearn.preprocessing import MinMaxScaler
 
-def load_and_split_data(path, window_size=15):
-    df = pd.read_csv(path)
 
-    feature_cols = [c for c in df.columns if c != "week"]
-    data = df[feature_cols].values
+def load_and_split_data(path: str, window_size: int = 15):
+    """Load CSV data and create windowed training and test splits.
 
-    scaler = MinMaxScaler()
-    data = scaler.fit_transform(data)
+    This function avoids heavy dependencies such as pandas or scikit-learn and
+    instead relies purely on ``numpy``. The CSV file is expected to have a
+    header row where the first column is ``week`` and the remaining columns are
+    the features with ``CoP`` being the first feature after ``week``.
+    """
+
+    raw = np.genfromtxt(path, delimiter=",", skip_header=1)
+
+    # Exclude the week column; perform min-max scaling manually
+    data = raw[:, 1:]
+    min_vals = data.min(axis=0)
+    max_vals = data.max(axis=0)
+    data = (data - min_vals) / (max_vals - min_vals + 1e-8)
 
     X, y = [], []
     for i in range(window_size, len(data)):
         X.append(data[i - window_size : i, :])
-        y.append(data[i, 0])  # predict CoP
+        y.append(data[i, 0])  # predict CoP (first feature)
 
     X, y = np.array(X), np.array(y)
 

--- a/ThermoTwinAI-Quantum/utils/quantum_layers.py
+++ b/ThermoTwinAI-Quantum/utils/quantum_layers.py
@@ -1,6 +1,5 @@
 # utils/quantum_layers.py
 import pennylane as qml
-from pennylane import numpy as np
 import torch
 from torch.nn import Module
 
@@ -9,33 +8,50 @@ dev = qml.device("default.qubit", wires=n_qubits)
 
 @qml.qnode(dev, interface="torch")
 def quantum_circuit(inputs, weights):
+    """Basic variational circuit used inside :class:`QuantumLayer`.
+
+    Args:
+        inputs (tensor): Rotational angles for the input layer.
+        weights (tensor): Trainable weights of the entangling layers.
+    """
+
+    # Encode features on the qubits
     for i in range(n_qubits):
         qml.RY(inputs[i], wires=i)
 
+    # Strong entanglement between qubits with a configurable depth
     qml.templates.StronglyEntanglingLayers(weights, wires=range(n_qubits))
     return [qml.expval(qml.PauliZ(i)) for i in range(n_qubits)]
 
+
 class QuantumLayer(Module):
-    def __init__(self):
+    """Thin wrapper around ``qml.qnn.TorchLayer`` allowing configurable depth.
+
+    Parameters
+    ----------
+    n_layers: int
+        Number of ``StronglyEntanglingLayers`` repetitions. Increasing this
+        value increases the expressive power of the quantum circuit at the
+        cost of additional simulation time.
+    """
+
+    def __init__(self, n_layers: int = 6):
         super().__init__()
-        weight_shapes = {"weights": (6, n_qubits, 3)}
+        weight_shapes = {"weights": (n_layers, n_qubits, 3)}
         self.q_layer = qml.qnn.TorchLayer(quantum_circuit, weight_shapes)
 
-    def forward(self, x):
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
         """Evaluate the underlying quantum circuit for a batch of inputs.
 
-        Pennylane's :class:`~pennylane.qnn.TorchLayer` does not
-        automatically broadcast over the batch dimension in some
-        environments. This wrapper manually iterates over the batch
-        dimension so that ``x`` can be of shape ``(batch, n_qubits)``.
+        Pennylane's :class:`~pennylane.qnn.TorchLayer` does not automatically
+        broadcast over the batch dimension in some environments. This wrapper
+        manually iterates over the batch dimension so that ``x`` can be of
+        shape ``(batch, n_qubits)``.
         """
 
         # Ensure batched tensor
         if x.ndim == 1:
             x = x.unsqueeze(0)
 
-        outputs = []
-        for sample in x:
-            outputs.append(self.q_layer(sample))
-
+        outputs = [self.q_layer(sample) for sample in x]
         return torch.stack(outputs, dim=0)


### PR DESCRIPTION
## Summary
- expand QLSTM with configurable depth, bidirectionality, and attention before a tunable quantum layer
- redesign QProphet with feature projection and deeper post-quantum network
- allow variable quantum layer depth and add CLI for window, epochs, and learning rate; generate richer multivariate synthetic data

## Testing
- `python main.py --epochs 1 --window 10 --lr 0.01` *(fails: ModuleNotFoundError: No module named 'numpy')*
- `pip install pandas scikit-learn torch pennylane numpy matplotlib --quiet` *(fails: Could not find a version that satisfies the requirement pandas)*

------
https://chatgpt.com/codex/tasks/task_e_688f30a28f048320aa1e218c95bfbdef