### PR TITLE
Improve quantum models with positional encoding and normalization

### DIFF
--- a/ThermoTwinAI-Quantum/models/quantum_prophet.py
+++ b/ThermoTwinAI-Quantum/models/quantum_prophet.py
@@ -38,7 +38,7 @@ class QProphetModel(nn.Module):
         self.q_layer = QuantumLayer(n_layers=q_depth)
 
         # Normalize quantum outputs before the classical head
-        self.norm = nn.LayerNorm(4)
+        self.norm = nn.BatchNorm1d(4)
 
         # Deeper classical post-quantum head
         self.classical_head = nn.Sequential(
@@ -58,6 +58,7 @@ class QProphetModel(nn.Module):
 
         x = self.feature_proj(cnn_out)
         x = self.q_layer(x)
+        x = torch.tanh(x)
         x = self.norm(x)
         return self.classical_head(x)
 


### PR DESCRIPTION
## Summary
- add sinusoidal positional encoding, residual link, and gated attention to QLSTM
- normalize Quantum NeuralProphet outputs with batch norm and deeper classical head

## Testing
- `python main.py --epochs 1 --window 10` *(fails: ModuleNotFoundError: No module named 'numpy')*
- `pip install numpy torch pennylane` *(fails: Could not connect to proxy)*
- `python -m py_compile models/quantum_lstm.py models/quantum_prophet.py`


------
https://chatgpt.com/codex/tasks/task_e_688f536f84cc832097a5593180e9596d