### PR TITLE
feat: add attention and streamlined quantum models

### DIFF
--- a/ThermoTwinAI-Quantum/models/quantum_prophet.py
+++ b/ThermoTwinAI-Quantum/models/quantum_prophet.py
@@ -1,12 +1,11 @@
 """Quantum-augmented NeuralProphet-style model.
 
-This module originally relied on heavy third-party libraries such as
-``torch`` and ``pennylane``.  Importing the file without those dependencies
-installed would raise an ``ImportError`` before the training helper function
-could be accessed, which in turn triggered the
-``ImportError: cannot import name 'train_quantum_prophet'`` message observed
-by users.  To make the failure mode clearer we attempt the imports lazily and
-provide a stub implementation when the dependencies are missing.
+The file lazily imports ``torch`` and ``pennylane`` so that the training helper
+remains importable even when the heavy dependencies are absent.  When the
+libraries are available the model uses a small 1D CNN with GELU activation to
+extract local temporal patterns, feeds the condensed representation through a
+shallow quantum layer (depth=1) and finishes with a compact MLP head.  The goal
+is to improve correlation while preserving CPU-level efficiency.
 """
 
 from typing import Any
@@ -28,7 +27,7 @@ else:  # pragma: no cover - executed only when deps are available
 
 if torch is not None:  # pragma: no cover - executed only when deps are available
     class QProphetModel(nn.Module):
-        """Linear projection into a quantum layer with a small classical head."""
+        """1D CNN features, quantum layer and a compact classical head."""
 
         def __init__(
             self,
@@ -39,25 +38,24 @@ if torch is not None:  # pragma: no cover - executed only when deps are availabl
         ) -> None:
             super().__init__()
 
-            # 1D convolution followed by ReLU prior to the quantum circuit
+            # 1D CNN → GELU smooths local patterns before the quantum circuit
             self.pre_q = nn.Sequential(
                 nn.Conv1d(num_features, n_qubits, kernel_size=3, padding=1),
-                nn.ReLU(),
+                nn.GELU(),
             )
 
             # Normalise to stabilise variance before entering the quantum circuit
-            self.norm = nn.LayerNorm(4)
+            self.norm = nn.LayerNorm(n_qubits)
 
-            # Quantum layer configured with depth=1
+            # Quantum layer configured with minimal depth (1 entangling layer)
             self.q_layer = QuantumLayer(n_layers=1)
 
-            # Post-quantum head: Linear(4→32) → BatchNorm1d → ReLU → Dropout(0.2) → Linear(32→1)
-            # ``dropout`` argument retained for backward compatibility but fixed
-            # to 0.2 as per the updated design.
+            # Post-QNode MLP: Linear(4→32) → BatchNorm1d → GELU → Dropout(0.2) → Linear(32→1)
+            # ``dropout`` argument retained for API compatibility.
             self.classical_head = nn.Sequential(
                 nn.Linear(n_qubits, 32),
                 nn.BatchNorm1d(32),
-                nn.ReLU(),
+                nn.GELU(),
                 nn.Dropout(0.2),
                 nn.Linear(32, 1),
             )
@@ -68,14 +66,14 @@ if torch is not None:  # pragma: no cover - executed only when deps are availabl
         def forward(self, x: torch.Tensor) -> torch.Tensor:
             # Input comes as (batch, seq, features); rearrange for Conv1d
             x = x.permute(0, 2, 1)
-            x = self.pre_q(x)  # conv + ReLU -> (batch, n_qubits, seq)
+            x = self.pre_q(x)  # conv + GELU -> (batch, n_qubits, seq)
 
             # Use only the last timestep then normalise before quantum layer
             x = x[:, :, -1]
             x = self.norm(x)
             x = self.q_layer(x)
             out = self.classical_head(x)
-            return out
+            return torch.clamp(out, -3, 3)
 
 
 def train_quantum_prophet(
@@ -83,7 +81,7 @@ def train_quantum_prophet(
     y_train: Any,
     X_test: Any,
     epochs: int = 50,
-    lr: float = 0.005,
+    lr: float = 0.001,
     hidden_dim: int = 32,
     q_depth: int = 2,
 ):
@@ -116,6 +114,7 @@ def train_quantum_prophet(
         output = model(X_train)
         loss = criterion(output, y_train)
         loss.backward()
+        torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm=1.0)
         optimizer.step()
         print(f"[QProphet] Epoch {epoch + 1}/{epochs} - Loss: {loss.item():.6f}")
 


### PR DESCRIPTION
## Summary
- enhance QLSTM with multi-head attention, residual fusion and GELU head
- refactor Quantum Prophet with CNN front-end, GELU activations and clamped outputs
- add gradient clipping and lower default LR for more stable training

## Testing
- `python ThermoTwinAI-Quantum/main.py --epochs 2 --lr 0.001` *(fails: ModuleNotFoundError: No module named 'numpy')*
- `pip install numpy torch pennylane matplotlib` *(fails: Could not connect to proxy / No matching distribution found)*

------
https://chatgpt.com/codex/tasks/task_e_688f82afe1fc83208beacf7224698925