### PR TITLE
Refine quantum models and adaptive training

### DIFF
--- a/ThermoTwinAI-Quantum/main.py
+++ b/ThermoTwinAI-Quantum/main.py
@@ -46,13 +46,21 @@ def main():
     parser = argparse.ArgumentParser(description="ThermoTwinAI-Quantum pipeline")
     parser.add_argument("--window", type=int, default=15, help="Sliding window size")
     parser.add_argument("--epochs", type=int, default=50, help="Training epochs")
-    parser.add_argument("--lr", type=float, default=0.005, help="Learning rate")
+    parser.add_argument(
+        "--lr",
+        type=float,
+        default=None,
+        help="Learning rate (default 0.005, or 0.001 when --use_drift is set)",
+    )
     parser.add_argument(
         "--use_drift",
         action="store_true",
         help="Enable z-score drift masking for training data",
     )
     args = parser.parse_args()
+
+    if args.lr is None:
+        args.lr = 0.001 if args.use_drift else 0.005
 
     print("🚀 ThermoTwinAI-Quantum Forecasting Pipeline")
 

--- a/ThermoTwinAI-Quantum/models/quantum_lstm.py
+++ b/ThermoTwinAI-Quantum/models/quantum_lstm.py
@@ -7,11 +7,13 @@ Optional convolutional smoothing is available to denoise inputs. The design
 keeps simulation costs low while improving correlation and stability.
 """
 
+import random
+import numpy as np
 import torch
 import torch.nn as nn
 
 from utils.quantum_layers import QuantumLayer, n_qubits
-from utils.drift_detection import DriftDetector
+from utils.drift_detection import DriftDetector, adjust_learning_rate
 
 
 class QLSTMModel(nn.Module):
@@ -22,7 +24,7 @@ class QLSTMModel(nn.Module):
         input_size: int,
         hidden_size: int = 16,
         q_depth: int = 2,
-        use_conv: bool = True,
+        use_conv: bool = False,
     ) -> None:
         super().__init__()
 
@@ -48,7 +50,7 @@ class QLSTMModel(nn.Module):
         # afterwards to stabilise training. ``q_depth`` retained for API
         # compatibility although the depth is fixed.
         self.q_layer = QuantumLayer(n_layers=1)
-        self.q_dropout = nn.Dropout(0.3)
+        self.q_dropout = nn.Dropout(0.1)
 
         # Output head: Linear(4→16) → GELU → Linear(16→1)
         self.fc1 = nn.Linear(n_qubits, 16)
@@ -66,10 +68,10 @@ class QLSTMModel(nn.Module):
         # LSTM produces representations for each timestep
         lstm_out, _ = self.lstm(x)  # (batch, seq, hidden)
 
-        # Residual fusion: last timestep + mean over sequence
+        # Residual fusion: average of last timestep and mean over sequence
         final = lstm_out[:, -1, :]
         mean = torch.mean(lstm_out, dim=1)
-        fused = final + mean
+        fused = (final + mean) * 0.5
 
         # Normalise and keep only the first n_qubits features for the QNode
         normed = self.ln(fused)
@@ -92,6 +94,11 @@ def train_quantum_lstm(
     drift_detector: DriftDetector | None = None,
 ):
     """Train ``QLSTMModel`` and return predictions for ``X_test``."""
+    torch.manual_seed(42)
+    np.random.seed(42)
+    random.seed(42)
+    if torch.cuda.is_available():
+        torch.cuda.manual_seed_all(42)
 
     device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
     num_features = X_train.shape[2]
@@ -104,7 +111,7 @@ def train_quantum_lstm(
     y_train = torch.tensor(y_train[:, None], dtype=torch.float32).to(device)
     X_test = torch.tensor(X_test, dtype=torch.float32).to(device)
 
-    def adapt_model() -> None:
+    def adapt_model(severity: float | None = None) -> None:
         """Retrain the final layers on the most recent window of data."""
         if drift_detector is None:
             return
@@ -116,6 +123,7 @@ def train_quantum_lstm(
         adapt_opt = torch.optim.Adam(
             filter(lambda p: p.requires_grad, model.parameters()), lr=lr
         )
+        adjust_learning_rate(adapt_opt, severity, lr)
         model.train()
         adapt_opt.zero_grad()
         out = model(x_recent)
@@ -138,9 +146,11 @@ def train_quantum_lstm(
         if drift_detector is not None:
             drift, prev, curr = drift_detector.update(mae)
             if drift:
+                severity = (curr - prev) / prev if prev else None
+                adjust_learning_rate(optimizer, severity, lr)
                 drift_detector.log("QLSTM", epoch + 1, prev, curr)
                 print(f"[QLSTM] Drift detected at epoch {epoch + 1}. Adapting...")
-                adapt_model()
+                adapt_model(severity)
 
         print(f"[QLSTM] Epoch {epoch + 1}/{epochs} - Loss: {loss.item():.6f}")
 


### PR DESCRIPTION
## Summary
- Lower default CLI learning rate to 0.001 when drift masking is used
- Disable conv smoothing and lighten quantum dropout in QLSTM, add seeding and severity-aware LR scaling
- Add mean pooling, lighter dropout, deterministic seeds and adaptive LR in Quantum Prophet

## Testing
- `python ThermoTwinAI-Quantum/main.py --epochs 1 --window 5 --use_drift` *(failed: ModuleNotFoundError: No module named 'numpy')*
- `pip install numpy torch pennylane` *(failed: Could not find a version that satisfies the requirement numpy)*
- `python -m py_compile ThermoTwinAI-Quantum/models/quantum_lstm.py ThermoTwinAI-Quantum/models/quantum_prophet.py ThermoTwinAI-Quantum/main.py`

------
https://chatgpt.com/codex/tasks/task_e_68907c74d140832081aaafb7473cf027