### PR TITLE
Align QProphet training with MAE-based optimisation

### DIFF
--- a/ThermoTwinAI-Quantum/README.md
+++ b/ThermoTwinAI-Quantum/README.md
@@ -52,7 +52,7 @@ The Quantum NeuralProphet module began as a minimalist feed‑forward network ap
 reshapes each multivariate window into a flat vector and compresses it through `feature_proj = nn.Linear(input_size, 4)`,
 as seen in [`models/quantum_prophet.py`](models/quantum_prophet.py). Those four features enter a `QuantumLayer` with
 `q_layers=8` before being processed by a classical network of width `hidden_dim=16`. The accompanying `train_quantum_prophet`
-routine trains for up to 50 epochs using an AdamW optimiser (`amsgrad=True`) with
+routine trains for up to 50 epochs, optimising an MAE loss with an AdamW optimiser (`amsgrad=True`) that applies light
 weight decay and a ReduceLROnPlateau scheduler at `lr=0.005` for safer
 convergence. An MAE‑based early stopping mechanism with a patience of ten
 epochs halts training if no improvement is observed. During tuning, hidden


### PR DESCRIPTION
## Summary
- Optimise Quantum NeuralProphet using MAE loss with AdamW to encourage stable, trend-aligned training
- Step ReduceLROnPlateau scheduler on MAE and log MAE each epoch for consistent early stopping
- Update documentation to describe the MAE-based training strategy alongside AdamW, weight decay and learning-rate scheduling

## Testing
- `python -m py_compile ThermoTwinAI-Quantum/models/quantum_prophet.py`
- `pip install numpy pandas torch pennylane` *(fails: Could not find a version that satisfies the requirement numpy)*

------
https://chatgpt.com/codex/tasks/task_e_6890840d68bc8320a7dbe03945a49d2e