### PR TITLE
Stabilize quantum models with augmentation safeguards

### DIFF
--- a/ThermoTwinAI-Quantum/utils/preprocessing.py
+++ b/ThermoTwinAI-Quantum/utils/preprocessing.py
@@ -41,6 +41,9 @@ def load_and_split_data(
 
     if use_augmentation:
         train_data = augment_time_series(train_data, seed=seed)
+        # Augmentation may slightly drift features outside the original
+        # min-max range; clip them back to preserve a stable distribution
+        train_data = np.clip(train_data, 0.0, 1.0)
 
     def create_windows(series: np.ndarray):
         X, y = [], []


### PR DESCRIPTION
## Summary
- Clip augmented training data back into its original range
- Use AdamW with scheduling and early stopping in the quantum LSTM
- Flip output weights for both models when training correlation is negative

## Testing
- `python -m py_compile ThermoTwinAI-Quantum/utils/preprocessing.py ThermoTwinAI-Quantum/models/quantum_lstm.py ThermoTwinAI-Quantum/models/quantum_prophet.py`
- `python ThermoTwinAI-Quantum/main.py --epochs 1 --use_augmentation` *(fails: ModuleNotFoundError: No module named 'numpy')*
- `pip install numpy pandas torch matplotlib pennylane -q` *(fails: ProxyError 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689089bd68ec83209dfe3a4cd2d368dd