### PR TITLE
Remove early stopping and revert risky quantum model tweaks

### DIFF
--- a/ThermoTwinAI-Quantum/models/quantum_lstm.py
+++ b/ThermoTwinAI-Quantum/models/quantum_lstm.py
@@ -105,17 +105,8 @@ def train_quantum_lstm(
     num_features = X_train.shape[2]
     model = QLSTMModel(num_features, hidden_size=hidden_size, q_depth=q_depth).to(device)
 
-    # Optimise MAE directly for robust, directionally correct forecasts
-    criterion = nn.L1Loss()
-    optimizer = torch.optim.AdamW(model.parameters(), lr=lr, weight_decay=1e-4, amsgrad=True)
-    scheduler = torch.optim.lr_scheduler.ReduceLROnPlateau(
-        optimizer, factor=0.5, patience=5, min_lr=1e-5
-    )
-
-    # Early stopping state
-    best_mae = float("inf")
-    epochs_no_improve = 0
-    patience = 10
+    criterion = nn.MSELoss()
+    optimizer = torch.optim.Adam(model.parameters(), lr=lr)
 
     X_train = torch.tensor(X_train, dtype=torch.float32).to(device)
     y_train = torch.tensor(y_train[:, None], dtype=torch.float32).to(device)
@@ -152,8 +143,7 @@ def train_quantum_lstm(
         torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm=1.0)
         optimizer.step()
 
-        mae = loss.item()
-        scheduler.step(mae)
+        mae = torch.nn.functional.l1_loss(output, y_train).item()
         if drift_detector is not None:
             drift, prev, curr = drift_detector.update(mae)
             if drift:
@@ -163,43 +153,19 @@ def train_quantum_lstm(
                 print(f"[QLSTM] Drift detected at epoch {epoch + 1}. Adapting...")
                 adapt_model(severity)
 
-        if mae < best_mae - 1e-6:
-            best_mae = mae
-            epochs_no_improve = 0
-        else:
-            epochs_no_improve += 1
-            if epochs_no_improve >= patience:
-                print(f"[QLSTM] Early stopping at epoch {epoch + 1}")
-                break
-
-        print(f"[QLSTM] Epoch {epoch + 1}/{epochs} - MAE: {mae:.6f}")
+        print(f"[QLSTM] Epoch {epoch + 1}/{epochs} - Loss: {loss.item():.6f}")
 
     # Evaluate correlation and error on training data for diagnostics
     model.eval()
     with torch.no_grad():
         train_preds = model(X_train).cpu()
+        preds = model(X_test).cpu().numpy().flatten()
 
+    # Pearson correlation and MSE on training set
     corr = float(
         torch.corrcoef(torch.stack((train_preds.squeeze(), y_train.squeeze())))[0, 1]
     )
     mse = nn.functional.mse_loss(train_preds, y_train).item()
-
-    if corr < 0:
-        with torch.no_grad():
-            model.fc2.weight.mul_(-1)
-            model.fc2.bias.mul_(-1)
-            train_preds = model(X_train).cpu()
-            corr = float(
-                torch.corrcoef(
-                    torch.stack((train_preds.squeeze(), y_train.squeeze()))
-                )[0, 1]
-            )
-            mse = nn.functional.mse_loss(train_preds, y_train).item()
-        print("[QLSTM] Output weights flipped to enforce positive correlation.")
-
-    with torch.no_grad():
-        preds = model(X_test).cpu().numpy().flatten()
-
     print(f"[QLSTM] Train Corr: {corr:.3f} - MSE: {mse:.6f}")
 
     return preds

--- a/ThermoTwinAI-Quantum/utils/preprocessing.py
+++ b/ThermoTwinAI-Quantum/utils/preprocessing.py
@@ -41,9 +41,6 @@ def load_and_split_data(
 
     if use_augmentation:
         train_data = augment_time_series(train_data, seed=seed)
-        # Augmentation may slightly drift features outside the original
-        # min-max range; clip them back to preserve a stable distribution
-        train_data = np.clip(train_data, 0.0, 1.0)
 
     def create_windows(series: np.ndarray):
         X, y = [], []


### PR DESCRIPTION
## Summary
- Revert quantum LSTM to Adam + MSE training and drop weight flipping and early stopping
- Strip early stopping and weight flipping from quantum NeuralProphet
- Stop clipping augmented data back to [0,1] to keep training distribution intact

## Testing
- `python -m py_compile ThermoTwinAI-Quantum/models/quantum_lstm.py ThermoTwinAI-Quantum/models/quantum_prophet.py ThermoTwinAI-Quantum/utils/preprocessing.py`
- `python ThermoTwinAI-Quantum/main.py --epochs 1` *(fails: ModuleNotFoundError: No module named 'numpy')*
- `pip install numpy torch pennylane pandas matplotlib` *(fails: Could not connect to proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68908c2516008320826b01a663c2fe50