### PR TITLE
Add Monte Carlo dropout uncertainty estimation

### DIFF
--- a/ThermoTwinAI-Quantum/evaluation/evaluate_models.py
+++ b/ThermoTwinAI-Quantum/evaluation/evaluate_models.py
@@ -8,8 +8,19 @@ except Exception:  # pragma: no cover - plotting is optional
     plt = None
 
 
-def evaluate_model(y_true, y_pred, name: str = "Model", plot: bool = False):
-    """Print common regression metrics and optionally plot predictions."""
+def evaluate_model(
+    y_true,
+    y_pred,
+    name: str = "Model",
+    plot: bool = False,
+    lower=None,
+    upper=None,
+):
+    """Print common regression metrics and optionally plot predictions.
+
+    When ``lower`` and ``upper`` bounds are provided, coverage and sharpness of
+    the predictive interval are also reported.
+    """
 
     # Ensure 1D arrays for stable metric calculations
     y_true = np.ravel(y_true)
@@ -28,11 +39,23 @@ def evaluate_model(y_true, y_pred, name: str = "Model", plot: bool = False):
     print(f"   RMSE    = {rmse:.6f}")
     print(f"   Corr(R) = {corr:.4f}")
 
+    if lower is not None and upper is not None:
+        lower = np.ravel(lower)
+        upper = np.ravel(upper)
+        coverage = np.mean((y_true >= lower) & (y_true <= upper))
+        sharpness = np.mean(upper - lower)
+        print(f"   Coverage = {coverage:.4f}")
+        print(f"   Sharpness = {sharpness:.6f}")
+
     if plot and plt is not None:
         os.makedirs("plots", exist_ok=True)
         plt.figure()
         plt.plot(y_true, label="True")
         plt.plot(y_pred, label="Predicted")
+        if lower is not None and upper is not None:
+            plt.fill_between(
+                np.arange(len(y_true)), lower, upper, color="gray", alpha=0.2
+            )
         plt.legend()
         plt.title(name)
         plt.tight_layout()

--- a/ThermoTwinAI-Quantum/utils/uncertainty.py
+++ b/ThermoTwinAI-Quantum/utils/uncertainty.py
@@ -1,0 +1,24 @@
+import numpy as np
+import torch
+
+
+def mc_dropout_predict(model: torch.nn.Module, x: torch.Tensor, n_samples: int = 30):
+    """Perform Monte Carlo Dropout predictions.
+
+    Returns the mean prediction, lower/upper 95% confidence bounds and the
+    predictive standard deviation.
+    """
+
+    device = next(model.parameters()).device
+    x = x.to(device)
+    model.eval()
+    preds = []
+    with torch.no_grad():
+        for _ in range(n_samples):
+            preds.append(model(x, mc_dropout=True).cpu().numpy())
+    preds = np.stack(preds, axis=0)
+    mean_pred = preds.mean(axis=0)
+    std_pred = preds.std(axis=0)
+    lower = mean_pred - 1.96 * std_pred
+    upper = mean_pred + 1.96 * std_pred
+    return mean_pred, lower, upper, std_pred


### PR DESCRIPTION
## Summary
- enable Monte Carlo dropout in Quantum LSTM and Quantum NeuralProphet for uncertainty-aware forecasts
- provide `mc_dropout_predict` utility and expose `--use_uq` CLI flag to activate interval predictions
- extend evaluation to report coverage and sharpness of prediction intervals

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_6890c5d5ea0083208ea2290b980a4389