### PR TITLE
feat: improve training stability

### DIFF
--- a/ThermoTwinAI-Quantum/README.md
+++ b/ThermoTwinAI-Quantum/README.md
@@ -2,6 +2,9 @@
 
 This project uses quantum-classical forecasting models to analyze degradation in TFTECs.
 
+The training utilities include configurable dropout rates and MAE-based early
+stopping to provide safer convergence when modelling noisy sensor data.
+
 ## Prototype Evolution
 Initial experiments relied on univariate signals. The latest prototype incorporates multi-sensor inputs and hyperparameter tuning, yielding the following changes:
 

--- a/ThermoTwinAI-Quantum/main.py
+++ b/ThermoTwinAI-Quantum/main.py
@@ -96,14 +96,28 @@ def main():
 
     print("\n🔮 Training Quantum LSTM...")
     qlstm_model, qlstm_preds = train_quantum_lstm(
-        X_train, y_train, X_test, epochs=args.epochs, lr=args.lr, drift_detector=drift_detector
+        X_train,
+        y_train,
+        X_test,
+        epochs=args.epochs,
+        lr=args.lr,
+        hidden_size=32,
+        dropout=0.1,
+        drift_detector=drift_detector,
     )
 
     drift_detector.reset()
 
     print("\n📈 Training Quantum NeuralProphet...")
     qprophet_model, qprophet_preds = train_quantum_prophet(
-        X_train, y_train, X_test, epochs=args.epochs, lr=args.lr, drift_detector=drift_detector
+        X_train,
+        y_train,
+        X_test,
+        epochs=args.epochs,
+        lr=args.lr,
+        hidden_dim=64,
+        dropout=0.1,
+        drift_detector=drift_detector,
     )
 
     print("\n📊 Evaluation:")


### PR DESCRIPTION
## Summary
- add configurable dropout and MAE-based early stopping to quantum LSTM
- expose dropout and early stopping in quantum NeuralProphet
- tune pipeline defaults for larger models with reduced regularization

## Testing
- `python -m py_compile models/quantum_lstm.py models/quantum_prophet.py main.py`
- `pip install torch==2.2.0 pennylane==0.32.0` *(fails: Cannot connect to proxy)*
- `pip install numpy` *(fails: Cannot connect to proxy)*
- `python main.py --epochs 1` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6890cf09a8308320a56e5397e2727b49