### PR TITLE
Fix benchmarks import path and add wrappers

### DIFF
--- a/ThermoTwinAI-Quantum/benchmarks/classical_models.py
+++ b/ThermoTwinAI-Quantum/benchmarks/classical_models.py
@@ -13,6 +13,7 @@ from evaluation.evaluate_models import evaluate_model
 from models.quantum_lstm import train_quantum_lstm
 from models.quantum_prophet import train_quantum_prophet
 from utils.preprocessing import load_and_split_data
+from pathlib import Path
 
 
 class VanillaLSTM(nn.Module):
@@ -67,8 +68,30 @@ def train_prophet_baseline(y_train, periods: int):  # pragma: no cover - heavy d
     return forecast
 
 
-def run_benchmarks(data_path: str = "data/synthetic_tftec_cop.csv", results_path: str = "results/benchmark_results.csv") -> None:
-    X_train, y_train, X_test, y_test = load_and_split_data(data_path)
+def run_benchmarks(
+    data_path: str | Path | None = None,
+    results_path: str | Path | None = None,
+) -> None:
+    """Run baseline and quantum benchmarks and write results to CSV.
+
+    Parameters
+    ----------
+    data_path:
+        Optional path to the CSV data file.  When ``None`` the synthetic
+        dataset bundled with the repository is used regardless of the current
+        working directory.
+    results_path:
+        Optional output CSV path.  When ``None`` results are written next to
+        the bundled data file.
+    """
+
+    root = Path(__file__).resolve().parent.parent
+    if data_path is None:
+        data_path = root / "data" / "synthetic_tftec_cop.csv"
+    if results_path is None:
+        results_path = root / "results" / "benchmark_results.csv"
+
+    X_train, y_train, X_test, y_test = load_and_split_data(str(data_path))
 
     rows = []
 

--- a/benchmarks/__init__.py
+++ b/benchmarks/__init__.py
@@ -1,0 +1,5 @@
+"""Expose benchmark modules from the project subpackage."""
+from pathlib import Path as _Path
+
+_pkg = _Path(__file__).resolve().parent.parent / "ThermoTwinAI-Quantum" / "benchmarks"
+__path__ = [str(_pkg)]

--- a/evaluation/__init__.py
+++ b/evaluation/__init__.py
@@ -1,0 +1,5 @@
+"""Expose evaluation modules from the project subpackage."""
+from pathlib import Path as _Path
+
+_pkg = _Path(__file__).resolve().parent.parent / "ThermoTwinAI-Quantum" / "evaluation"
+__path__ = [str(_pkg)]

--- a/models/__init__.py
+++ b/models/__init__.py
@@ -1,0 +1,5 @@
+"""Expose model modules from the project subpackage."""
+from pathlib import Path as _Path
+
+_pkg = _Path(__file__).resolve().parent.parent / "ThermoTwinAI-Quantum" / "models"
+__path__ = [str(_pkg)]

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -1,0 +1,5 @@
+"""Expose utility modules from the project subpackage."""
+from pathlib import Path as _Path
+
+_pkg = _Path(__file__).resolve().parent.parent / "ThermoTwinAI-Quantum" / "utils"
+__path__ = [str(_pkg)]


### PR DESCRIPTION
## Summary
- expose internal packages (benchmarks, evaluation, models, utils) at repo root so modules can be imported directly
- make benchmark script resolve data paths relative to its file

## Testing
- `python - <<'PY'
try:
    from benchmarks.classical_models import run_benchmarks
    print('Import success:', run_benchmarks)
except Exception as e:
    print('Import error:', e)
PY`
- `pytest >/tmp/pytest.log && tail -n 20 /tmp/pytest.log`


------
https://chatgpt.com/codex/tasks/task_e_6890f00d9a108320b1beccf7b1fde826