### PR TITLE
Fix notebook module path for benchmarks import

### DIFF
--- a/ThermoTwinAI-Quantum/notebooks/Benchmark_And_Visualization.ipynb
+++ b/ThermoTwinAI-Quantum/notebooks/Benchmark_And_Visualization.ipynb
@@ -6,7 +6,7 @@
    "source": [
     "# Benchmark and Visualization\n",
     "This notebook trains classical and quantum models on the TFTEC dataset,\n",
-    "plots forecasts, uncertainty bands and feature importances." 
+    "plots forecasts, uncertainty bands and feature importances."
    ]
   },
   {
@@ -15,8 +15,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import sys\n",
+    "from pathlib import Path\n",
+    "sys.path.append(str(Path().resolve().parent))\n",
     "from benchmarks.classical_models import run_benchmarks\n",
-    "run_benchmarks()\n" 
+    "run_benchmarks()\n"
    ]
   }
  ],


### PR DESCRIPTION
## Summary
- ensure Benchmark_And_Visualization notebook can import repository modules by appending its parent directory to `sys.path`

## Testing
- `pytest` (no tests found)


------
https://chatgpt.com/codex/tasks/task_e_6890f41b23b08320bf71e7f60c401be3