### PR TITLE
Add missing package marker for quantum models

### DIFF
--- a/ThermoTwinAI-Quantum/models/__init__.py
+++ b/ThermoTwinAI-Quantum/models/__init__.py
@@ -1,0 +1,8 @@
+"""ThermoTwinAI-Quantum model package.
+
+The presence of this file marks the ``models`` directory as a package so that
+modules like :mod:`models.quantum_lstm` can be imported when executing
+``main.py`` directly.
+"""
+
+__all__ = []


### PR DESCRIPTION
## Summary
- ensure ThermoTwinAI-Quantum models directory is recognised as a package to fix ModuleNotFoundError

## Testing
- `python - <<'PY'
import sys, importlib.util
sys.path.insert(0, 'ThermoTwinAI-Quantum')
print('findspec models.quantum_lstm:', importlib.util.find_spec('models.quantum_lstm') is not None)
print('findspec models.quantum_prophet:', importlib.util.find_spec('models.quantum_prophet') is not None)
PY`

------
https://chatgpt.com/codex/tasks/task_e_6890f5be9368832081b5a7d3fe180ed9