### PR TITLE
Resolve merge artifacts in quantum models package

### DIFF
--- a/ThermoTwinAI-Quantum/models/__init__.py
+++ b/ThermoTwinAI-Quantum/models/__init__.py
@@ -5,4 +5,7 @@ modules like :mod:`models.quantum_lstm` can be imported when executing
 ``main.py`` directly.
 """
 
-__all__ = []
+from .quantum_lstm import train_quantum_lstm
+from .quantum_prophet import train_quantum_prophet
+
+__all__ = ["train_quantum_lstm", "train_quantum_prophet"]


### PR DESCRIPTION
## Summary
- clean up `ThermoTwinAI-Quantum/models/__init__.py` after merge conflict
- re-export training functions `train_quantum_lstm` and `train_quantum_prophet`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6890f792fd4c832094d6394c80f2a8ee