### PR TITLE
Improve Python 3.8 compatibility

### DIFF
--- a/ThermoTwinAI-Quantum/analysis/feature_importance.py
+++ b/ThermoTwinAI-Quantum/analysis/feature_importance.py
@@ -1,12 +1,13 @@
 """Feature importance analysis using SHAP."""
 
-from __future__ import annotations
-
 import numpy as np
 import torch
+from typing import Optional
 
 
-def compute_feature_importance(model: torch.nn.Module, X: np.ndarray, top_k: int | None = None):
+def compute_feature_importance(
+    model: torch.nn.Module, X: np.ndarray, top_k: Optional[int] = None
+):
     """Compute feature importance for the classical portion of ``model``.
 
     Parameters

--- a/ThermoTwinAI-Quantum/benchmarks/classical_models.py
+++ b/ThermoTwinAI-Quantum/benchmarks/classical_models.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import csv
 from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional, Union
 
 import numpy as np
 import torch
@@ -13,7 +15,6 @@ from evaluation.evaluate_models import evaluate_model
 from models.quantum_lstm import train_quantum_lstm
 from models.quantum_prophet import train_quantum_prophet
 from utils.preprocessing import load_and_split_data
-from pathlib import Path
 
 
 class VanillaLSTM(nn.Module):
@@ -69,8 +70,8 @@ def train_prophet_baseline(y_train, periods: int):  # pragma: no cover - heavy d
 
 
 def run_benchmarks(
-    data_path: str | Path | None = None,
-    results_path: str | Path | None = None,
+    data_path: Optional[Union[str, Path]] = None,
+    results_path: Optional[Union[str, Path]] = None,
 ) -> None:
     """Run baseline and quantum benchmarks and write results to CSV.
 

--- a/ThermoTwinAI-Quantum/hpo/tune_params.py
+++ b/ThermoTwinAI-Quantum/hpo/tune_params.py
@@ -1,10 +1,9 @@
 """Hyperparameter tuning utilities for quantum models."""
 
-from __future__ import annotations
-
 import itertools
 import random
 from dataclasses import dataclass
+from typing import Optional
 
 import numpy as np
 
@@ -24,7 +23,7 @@ def grid_search(model: str, param_grid: dict, data_path: str) -> TrialResult:
     """Exhaustively evaluate all combinations in ``param_grid``."""
 
     X_train, y_train, X_test, y_test = load_and_split_data(data_path)
-    best: TrialResult | None = None
+    best: Optional[TrialResult] = None
 
     keys = list(param_grid.keys())
     for values in itertools.product(*param_grid.values()):
@@ -63,7 +62,7 @@ def random_search(model: str, param_grid: dict, data_path: str, n_iter: int = 10
     """Sample ``n_iter`` random combinations from ``param_grid``."""
 
     X_train, y_train, X_test, y_test = load_and_split_data(data_path)
-    best: TrialResult | None = None
+    best: Optional[TrialResult] = None
 
     keys = list(param_grid.keys())
     for _ in range(n_iter):

--- a/ThermoTwinAI-Quantum/models/quantum_lstm.py
+++ b/ThermoTwinAI-Quantum/models/quantum_lstm.py
@@ -8,6 +8,8 @@ keeps simulation costs low while improving correlation and stability.
 """
 
 import random
+from typing import Optional, Tuple
+
 import numpy as np
 import torch
 import torch.nn as nn
@@ -130,9 +132,9 @@ def train_quantum_lstm(
     hidden_size: int = 16,
     q_depth: int = 2,
     dropout: float = 0.25,
-    drift_detector: DriftDetector | None = None,
+    drift_detector: Optional[DriftDetector] = None,
     patience: int = 10,
-) -> tuple[nn.Module, np.ndarray]:
+) -> Tuple[nn.Module, np.ndarray]:
     """Train ``QLSTMModel`` and return the model with predictions for ``X_test``."""
     torch.manual_seed(42)
     np.random.seed(42)
@@ -160,7 +162,7 @@ def train_quantum_lstm(
     y_train = torch.tensor(y_train[:, None], dtype=torch.float32).to(device)
     X_test = torch.tensor(X_test, dtype=torch.float32).to(device)
 
-    def adapt_model(severity: float | None = None) -> None:
+    def adapt_model(severity: Optional[float] = None) -> None:
         """Retrain the final layers on the most recent window of data."""
         if drift_detector is None:
             return

--- a/ThermoTwinAI-Quantum/models/quantum_prophet.py
+++ b/ThermoTwinAI-Quantum/models/quantum_prophet.py
@@ -7,7 +7,7 @@ them through a two-layer entangling quantum circuit and applies a small MLP
 head. Dropout layers around the quantum circuit help stabilise training.
 """
 
-from typing import Any
+from typing import Any, Optional, Tuple
 
 from utils.drift_detection import DriftDetector, adjust_learning_rate
 
@@ -101,9 +101,9 @@ def train_quantum_prophet(
     hidden_dim: int = 32,
     q_depth: int = 2,
     dropout: float = 0.25,
-    drift_detector: DriftDetector | None = None,
+    drift_detector: Optional[DriftDetector] = None,
     patience: int = 10,
-) -> tuple[Any, Any]:
+) -> Tuple[Any, Any]:
     """Train ``QProphetModel`` and return the model with predictions for ``X_test``.
 
     If the optional dependencies (``torch`` and ``pennylane``) are not
@@ -144,7 +144,7 @@ def train_quantum_prophet(
     y_train = torch.tensor(y_train[:, None], dtype=torch.float32).to(device)
     X_test = torch.tensor(X_test, dtype=torch.float32).to(device)
 
-    def adapt_model(severity: float | None = None) -> None:
+    def adapt_model(severity: Optional[float] = None) -> None:
         if drift_detector is None:
             return
         window = drift_detector.window_size

--- a/ThermoTwinAI-Quantum/utils/data_augmentation.py
+++ b/ThermoTwinAI-Quantum/utils/data_augmentation.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 import numpy as np
 
 
@@ -7,7 +9,7 @@ def augment_time_series(
     add_scale: bool = True,
     add_seasonal: bool = True,
     add_warp: bool = True,
-    seed: int | None = None,
+    seed: Optional[int] = None,
 ) -> np.ndarray:
     """Augment a multivariate time series using several techniques.
 

--- a/ThermoTwinAI-Quantum/utils/preprocessing.py
+++ b/ThermoTwinAI-Quantum/utils/preprocessing.py
@@ -2,6 +2,8 @@
 import numpy as np
 import torch
 import torch.nn as nn
+from typing import Optional
+
 from utils.data_augmentation import augment_time_series
 
 
@@ -28,7 +30,7 @@ def load_and_split_data(
     path: str,
     window_size: int = 15,
     use_augmentation: bool = False,
-    seed: int | None = 42,
+    seed: Optional[int] = 42,
 ):
     """Load CSV data and create windowed training and test splits.
 


### PR DESCRIPTION
## Summary
- use typing.Optional/Union/Tuple instead of `|` unions across modules
- import typing helpers so modules run on Python 3.8

## Testing
- `python -m py_compile analysis/feature_importance.py benchmarks/classical_models.py hpo/tune_params.py models/quantum_lstm.py models/quantum_prophet.py utils/data_augmentation.py utils/preprocessing.py`
- `pip install numpy pandas torch pennylane` *(fails: Could not find a version that satisfies the requirement numpy)*
- `python main.py --epochs 1 --model q_lstm` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6890f9c04ab88320bdfcdff27f0c6410