### PR TITLE
Cleanup quantum models init

### DIFF
--- a/ThermoTwinAI-Quantum/models/__init__.py
+++ b/ThermoTwinAI-Quantum/models/__init__.py
@@ -1,8 +1,11 @@
 """ThermoTwinAI-Quantum model package.
 
-The presence of this file marks the ``models`` directory as a package so that
-modules like :mod:`models.quantum_lstm` can be imported when executing
-``main.py`` directly.
+This file makes the ``models`` directory importable and re-exports the
+training helpers defined in :mod:`quantum_lstm` and
+:mod:`quantum_prophet`.  Earlier merge artifacts left conflict markers in
+this module, producing a ``SyntaxError`` when ``main.py`` attempted to
+import it.  The conflict markers have been removed and the public API is
+now explicitly defined via ``__all__``.
 """
 
 from .quantum_lstm import train_quantum_lstm


### PR DESCRIPTION
## Summary
- clarify quantum models package and re-export training helpers
- document fix for previous merge artifact that caused SyntaxError

## Testing
- `python -m py_compile ThermoTwinAI-Quantum/models/__init__.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6890f919ffe48320b6f494d11f24ff03