### PR TITLE
Fix evaluation module imports

### DIFF
--- a/ThermoTwinAI-Quantum/evaluation/__init__.py
+++ b/ThermoTwinAI-Quantum/evaluation/__init__.py
@@ -1,0 +1,5 @@
+"""Evaluation utilities for model assessment."""
+
+from .evaluate_models import evaluate_model
+
+__all__ = ["evaluate_model"]

--- a/evaluation/__init__.py
+++ b/evaluation/__init__.py
@@ -1,5 +1,0 @@
-"""Expose evaluation modules from the project subpackage."""
-from pathlib import Path as _Path
-
-_pkg = _Path(__file__).resolve().parent.parent / "ThermoTwinAI-Quantum" / "evaluation"
-__path__ = [str(_pkg)]


### PR DESCRIPTION
## Summary
- remove redundant top-level `evaluation` package
- add proper `__init__` in `ThermoTwinAI-Quantum/evaluation` to expose evaluation utilities

## Testing
- `python -m py_compile ThermoTwinAI-Quantum/evaluation/__init__.py ThermoTwinAI-Quantum/evaluation/evaluate_models.py ThermoTwinAI-Quantum/main.py ThermoTwinAI-Quantum/hpo/tune_params.py ThermoTwinAI-Quantum/benchmarks/classical_models.py`
- `pip install numpy` *(fails: Could not find a version that satisfies the requirement numpy)*

------
https://chatgpt.com/codex/tasks/task_e_689c72e537008320b7c39b91beb601e5