### PR TITLE
Integrate adaptive causal graph attention into quantum models

### DIFF
--- a/ThermoTwinAI-Quantum/tests/test_acga.py
+++ b/ThermoTwinAI-Quantum/tests/test_acga.py
@@ -1,0 +1,23 @@
+import pytest
+
+try:  # pragma: no cover - used only when torch is available
+    import torch
+except Exception:  # pragma: no cover - torch missing in minimal envs
+    torch = None
+
+if torch is None:  # pragma: no cover - skip module import when torch missing
+    pytest.skip("torch not installed", allow_module_level=True)
+
+from utils.causal_graph_attention import AdaptiveCausalGraphAttention
+from utils.quantum_layers import n_qubits
+
+
+def test_acga_shape_and_lambda_adjust():
+    acga = AdaptiveCausalGraphAttention(n_sensors=5, out_dim=n_qubits)
+    x = torch.randn(2, 10, 5)
+    emb = acga(x)
+    assert emb.shape == (2, n_qubits)
+    lam0 = acga.lambda_value().item()
+    acga.adjust_lambda(0.5)
+    lam1 = acga.lambda_value().item()
+    assert lam1 > lam0

--- a/ThermoTwinAI-Quantum/utils/causal_graph_attention.py
+++ b/ThermoTwinAI-Quantum/utils/causal_graph_attention.py
@@ -1,0 +1,39 @@
+import torch
+import torch.nn as nn
+
+from .quantum_layers import n_qubits
+
+
+class AdaptiveCausalGraphAttention(nn.Module):
+    """Learn sensor-wise causal influence via self-attention."""
+
+    def __init__(self, n_sensors: int, out_dim: int | None = None, n_heads: int = 4) -> None:
+        super().__init__()
+        out_dim = out_dim or n_qubits
+        # Ensure valid head configuration
+        n_heads = max(1, min(n_heads, n_sensors))
+        if n_sensors % n_heads != 0:
+            n_heads = 1
+        self.attn = nn.MultiheadAttention(
+            embed_dim=n_sensors, num_heads=n_heads, batch_first=True
+        )
+        self.proj = nn.Linear(n_sensors, out_dim)
+        self._lambda = nn.Parameter(torch.zeros(1))
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """Return a causal embedding of shape ``(batch, out_dim)``."""
+        if x.dim() == 3:
+            x = x.mean(dim=1)
+        x = x.unsqueeze(1)
+        attn_out, _ = self.attn(x, x, x)
+        attn_out = attn_out.squeeze(1)
+        return self.proj(attn_out)
+
+    def lambda_value(self) -> torch.Tensor:
+        return torch.sigmoid(self._lambda)
+
+    def adjust_lambda(self, severity: float | None) -> None:
+        if severity is None:
+            return
+        with torch.no_grad():
+            self._lambda.add_(float(severity))


### PR DESCRIPTION
## Summary
- add AdaptiveCausalGraphAttention module for sensor-wise causal influence with drift-adaptive gate
- fuse ACGA embeddings into Quantum LSTM and QProphet models and update drift adaptation
- add unit test for ACGA shape and lambda adjustment

## Testing
- `PYTHONPATH=ThermoTwinAI-Quantum pytest -q ThermoTwinAI-Quantum/tests/test_acga.py` *(skipped: torch not installed)*

------
https://chatgpt.com/codex/tasks/task_e_689c77d3c4908320836da2c3f5a979ea