### PR TITLE
Fix benchmark notebook imports and result display

### DIFF
--- a/ThermoTwinAI-Quantum/notebooks/Benchmark_And_Visualization.ipynb
+++ b/ThermoTwinAI-Quantum/notebooks/Benchmark_And_Visualization.ipynb
@@ -6,7 +6,7 @@
    "source": [
     "# Benchmark and Visualization\n",
     "This notebook trains classical and quantum models on the TFTEC dataset,\n",
-    "plots forecasts, uncertainty bands and feature importances." 
+    "plots forecasts, uncertainty bands and feature importances."
    ]
   },
   {
@@ -15,8 +15,17 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "from pathlib import Path\n",
+    "import sys\n",
+    "import pandas as pd\n",
+    "\n",
+    "root = Path('..').resolve()\n",
+    "sys.path.append(str(root))\n",
+    "\n",
     "from benchmarks.classical_models import run_benchmarks\n",
-    "run_benchmarks()\n" 
+    "\n",
+    "run_benchmarks()\n",
+    "pd.read_csv(root / 'results' / 'benchmark_results.csv')\n"
    ]
   }
  ],


### PR DESCRIPTION
## Summary
- Ensure benchmark notebook can locate project modules by appending project root to `sys.path`
- Display benchmark results by reading generated CSV and returning it in the final cell

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689c7ebfb3a08320865cc755b3ddd447