### PR TITLE
Refine quantum models prediction range and evaluation

### DIFF
--- a/ThermoTwinAI-Quantum/models/quantum_prophet.py
+++ b/ThermoTwinAI-Quantum/models/quantum_prophet.py
@@ -97,7 +97,7 @@ if torch is not None:  # pragma: no cover - executed only when deps are availabl
                 x, p=self.fc1_dropout.p, training=self.training or mc_dropout
             )
             out = self.fc2(x)
-            return torch.clamp(out, -3, 3)
+            return out
 
 
 def train_quantum_prophet(


### PR DESCRIPTION
## Summary
- Allow LSTM and Prophet models to emit unclamped predictions for wider dynamic range
- Recompute test predictions after sign correction in QLSTM training loop

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689c8d375edc832089ba3664a4cd6e1d