### PR TITLE
Enable unscaled plotting of model predictions

### DIFF
--- a/ThermoTwinAI-Quantum/main.py
+++ b/ThermoTwinAI-Quantum/main.py
@@ -86,11 +86,13 @@ def main():
 
     df = pd.read_csv("data/synthetic_tftec_cop.csv")
 
-    X_train, y_train, X_test, y_test = load_and_split_data(
+    X_train, y_train, X_test, y_test, min_vals, max_vals = load_and_split_data(
         "data/synthetic_tftec_cop.csv",
         window_size=args.window,
         use_augmentation=args.use_augmentation,
+        return_scaler=True,
     )
+    cop_min, cop_max = float(min_vals[0]), float(max_vals[0])
 
     if args.use_drift:
         drift_flags = detect_drift(df["CoP"])
@@ -146,6 +148,7 @@ def main():
                 plot=True,
                 lower=lower_lstm.flatten(),
                 upper=upper_lstm.flatten(),
+                scaler=(cop_min, cop_max),
             )
             evaluate_acga(qlstm_model.acga, name="qlstm_acga")
         if qprophet_model is not None:
@@ -163,14 +166,27 @@ def main():
                 plot=True,
                 lower=lower_prophet.flatten(),
                 upper=upper_prophet.flatten(),
+                scaler=(cop_min, cop_max),
             )
             evaluate_acga(qprophet_model.acga, name="qprophet_acga")
     else:
         if qlstm_preds is not None:
-            evaluate_model(y_test, qlstm_preds, name="Quantum LSTM", plot=True)
+            evaluate_model(
+                y_test,
+                qlstm_preds,
+                name="Quantum LSTM",
+                plot=True,
+                scaler=(cop_min, cop_max),
+            )
             evaluate_acga(qlstm_model.acga, name="qlstm_acga")
         if qprophet_preds is not None:
-            evaluate_model(y_test, qprophet_preds, name="Quantum NeuralProphet", plot=True)
+            evaluate_model(
+                y_test,
+                qprophet_preds,
+                name="Quantum NeuralProphet",
+                plot=True,
+                scaler=(cop_min, cop_max),
+            )
             evaluate_acga(qprophet_model.acga, name="qprophet_acga")
 
 if __name__ == "__main__":

--- a/ThermoTwinAI-Quantum/utils/preprocessing.py
+++ b/ThermoTwinAI-Quantum/utils/preprocessing.py
@@ -29,6 +29,7 @@ def load_and_split_data(
     window_size: int = 15,
     use_augmentation: bool = False,
     seed: int | None = 42,
+    return_scaler: bool = False,
 ):
     """Load CSV data and create windowed training and test splits.
 
@@ -81,5 +82,8 @@ def load_and_split_data(
 
     X_train, y_train = create_windows(train_data)
     X_test, y_test = create_windows(test_data)
+
+    if return_scaler:
+        return X_train, y_train, X_test, y_test, min_vals, max_vals
 
     return X_train, y_train, X_test, y_test


### PR DESCRIPTION
## Summary
- return min/max values from `load_and_split_data` when requested
- allow `evaluate_model` to inverse-scale outputs for clearer plots
- pass scaling info through main pipeline so plots reflect original units

## Testing
- ⚠️ `pytest -q` (skipped: missing dependencies)


------
https://chatgpt.com/codex/tasks/task_e_689c902f78a0832090fccc2950a81824